### PR TITLE
README.md with intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+
+Open Editors is an eclipse plugin. It adds a view that shows all open editors in a vertical list. 
+You can sort the list by Name or Path and items can be "pinned" to the top.
+
+This is alternative to Eclipse built-in "Switch to Editor" dialog (<kbd>Ctrl+Shift+E</kbd>), that is modal.
+
+Published on <https://marketplace.eclipse.org/content/open-editors>
+


### PR DESCRIPTION
Open Editors is an eclipse plugin. It adds a view that shows all open editors in a vertical list. 
You can sort the list by Name or Path and items can be "pinned" to the top.

This is alternative to Eclipse built-in "Switch to Editor" dialog (<kbd>Ctrl+Shift+E</kbd>), that is modal.

Published on <https://marketplace.eclipse.org/content/open-editors>
