### PR TITLE
update view when editor isDirty changes using IPropertyListener

### DIFF
--- a/src/com/deepnoodle/openeditors/models/settings/SettingsModel.java
+++ b/src/com/deepnoodle/openeditors/models/settings/SettingsModel.java
@@ -14,6 +14,7 @@ public class SettingsModel {
 	private RGB highlightColor = new RGB(219, 219, 219);
 	private RGB pinnedColor = new RGB(60, 15, 175);
 	private RGB dirtyColor = new RGB(204, 0, 0);
+	private RGB closedColor = new RGB(130, 130, 130);
 
 	private String activeSetName = Constants.OPEN_EDITORS_SET_NAME;
 
@@ -32,7 +33,15 @@ public class SettingsModel {
 	public void setHighlightColor(RGB highlightColor) {
 		this.highlightColor = highlightColor;
 	}
-
+	
+	public RGB getClosedColor() {
+		return closedColor;
+	}
+	
+	public void setClosedColor(RGB closedColor) {
+		this.closedColor = closedColor;
+	}
+	
 	public RGB getPinnedColor() {
 		return pinnedColor;
 	}

--- a/src/com/deepnoodle/openeditors/services/SettingsService.java
+++ b/src/com/deepnoodle/openeditors/services/SettingsService.java
@@ -135,6 +135,10 @@ public class SettingsService {
 		return getOrCreateSettings().getHighlightColor();
 	}
 
+	public RGB getClosedColor() {
+		return getOrCreateSettings().getClosedColor();
+	}
+	
 	public EditorSetSettingsModel getActiveEditorSettingsSet() {
 		return getOrCreateSettings().getActiveEditorSettingsSet();
 	}

--- a/src/com/deepnoodle/openeditors/views/openeditors/EditorRowFormatter.java
+++ b/src/com/deepnoodle/openeditors/views/openeditors/EditorRowFormatter.java
@@ -1,7 +1,6 @@
 package com.deepnoodle.openeditors.views.openeditors;
 
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.TableItem;
 
@@ -12,10 +11,23 @@ import com.deepnoodle.openeditors.services.SettingsService;
 public class EditorRowFormatter {
 
 	private static LogWrapper log = new LogWrapper(EditorTableView.class);
-
-	private SettingsService settingsService = SettingsService.getInstance();
-
 	private static EditorRowFormatter instance;
+
+	private SettingsService settingsService;
+
+	private Color dirtyColor;
+	private Color pinnedColor;
+	private Color highlightColor;
+	private Color closedColor;
+
+	private EditorRowFormatter() {
+		settingsService = SettingsService.getInstance();
+
+		dirtyColor = new Color(Display.getCurrent(), settingsService.getDirtyColor());
+		pinnedColor = new Color(Display.getCurrent(), settingsService.getPinnedColor());
+		highlightColor = new Color(Display.getCurrent(), settingsService.getHighlightColor());
+		closedColor = new Color(Display.getCurrent(), settingsService.getClosedColor());
+	}
 
 	public static EditorRowFormatter getInstance() {
 		if (instance == null) {
@@ -25,20 +37,11 @@ public class EditorRowFormatter {
 	}
 
 	public void formatRows(TableItem[] items, IEditor activeEditor, Color forgroundColor, Color backgroundColor) {
-
-		Color dirtyColor = new Color(Display.getCurrent(), settingsService.getDirtyColor());
-		Color pinnedColor = new Color(Display.getCurrent(), settingsService.getPinnedColor());
-		Color highlightColor = new Color(Display.getCurrent(), settingsService.getHighlightColor());
-
-		//TODO move to settings
-		Color closedColor = new Color(Display.getCurrent(), new RGB(130, 130, 130));
-
 		for (TableItem item : items) {
 			try {
 				IEditor editor = ((IEditor) item.getData());
 				if (editor.isPinned()) {
 					item.setForeground(pinnedColor);
-					//item.setFont(new F);
 				} else if (!editor.isOpened()) {
 					item.setForeground(closedColor);
 				} else if (editor.isDirty()) {

--- a/src/com/deepnoodle/openeditors/views/openeditors/EditorViewLabelProvider.java
+++ b/src/com/deepnoodle/openeditors/views/openeditors/EditorViewLabelProvider.java
@@ -12,7 +12,12 @@ class EditorViewLabelProvider extends LabelProvider implements ITableLabelProvid
 
 	@Override
 	public String getColumnText(Object obj, int index) {
-		return getText(obj);
+		IEditor editor = ((IEditor) obj);
+		if (editor.isDirty()) {
+			return "*"+getText(obj);
+		} else {
+			return getText(obj);
+		}
 	}
 
 	@Override

--- a/src/com/deepnoodle/openeditors/views/openeditors/OpenEditorsMainView.java
+++ b/src/com/deepnoodle/openeditors/views/openeditors/OpenEditorsMainView.java
@@ -2,12 +2,10 @@ package com.deepnoodle.openeditors.views.openeditors;
 
 import javax.annotation.PostConstruct;
 
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IActionBars;
-import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.part.ViewPart;
 
 import com.deepnoodle.openeditors.actions.SortAction;
@@ -18,20 +16,18 @@ public class OpenEditorsMainView extends ViewPart {
 
 	private EditorTableView editorTableView;
 
+	private PartListener partListener;
+	
 	@Override
 	@PostConstruct
 	public void createPartControl(Composite parent) {
 
-		final IWorkbenchWindow workbenchWindow = getSite().getWorkbenchWindow();
-
 		//Build the editor view
 		editorTableView = new EditorTableView(parent, getSite(), getViewSite());
 
-		PartListener listener = new PartListener(editorTableView);
-		workbenchWindow.getPartService().addPartListener(listener);
-
-		ResourcesPlugin.getWorkspace().addResourceChangeListener(listener);
-
+		partListener = new PartListener(editorTableView);
+		getSite().getWorkbenchWindow().getPartService().addPartListener(partListener);
+		
 		//EditorSetComboControl editorSetComboControl = new EditorSetComboControl(editorTableView);
 
 //		Action loadSetAction = new ManageSetsAction(editorSetComboControl);
@@ -70,7 +66,12 @@ public class OpenEditorsMainView extends ViewPart {
 	@Override
 	public void setFocus() {
 		// Do nothing
-
 	}
 
+	@Override
+	public void dispose() {
+		// Remove all listeners
+		getSite().getWorkbenchWindow().getPartService().removePartListener(partListener);
+		editorTableView.dispose();
+	}
 }

--- a/src/com/deepnoodle/openeditors/views/openeditors/PartListener.java
+++ b/src/com/deepnoodle/openeditors/views/openeditors/PartListener.java
@@ -1,12 +1,10 @@
 package com.deepnoodle.openeditors.views.openeditors;
 
-import org.eclipse.core.resources.IResourceChangeEvent;
-import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.ui.IPartListener;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.EditorPart;
 
-public class PartListener implements IPartListener, IResourceChangeListener {
+public class PartListener implements IPartListener {
 	private EditorTableView editorTableView;
 
 	public PartListener(EditorTableView editorTableView) {
@@ -45,12 +43,7 @@ public class PartListener implements IPartListener, IResourceChangeListener {
 
 	@Override
 	public void partDeactivated(IWorkbenchPart part) {
-		//Do nothing
+		// Do nothing
+		editorTableView.setActivePart(null);
 	}
-
-	@Override
-	public void resourceChanged(IResourceChangeEvent event) {
-		//editorTableView.refresh();
-	}
-
 }


### PR DESCRIPTION
1. update view when editor isDirty changes using IPropertyListener
2. removed IResourceChangeListener because it was not used and is potentially costly when lots of files change (e.g. in a build)
3. remove listeners when view is disposed (fixes exceptions when closing and re-opening the view)

See: #23 